### PR TITLE
fix: Change admin access method for mobile compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1204,20 +1204,17 @@
         function handleHashChange() {
             const hash = window.location.hash;
             if (hash === '#admin') {
-                if (isAdminLoggedIn) {
-                    // Si ya ha iniciado sesión, muestra el panel directamente
-                    sections.forEach(section => {
-                        section.classList.remove('active');
-                    });
-                    adminPanelSection.classList.add('active');
-                    if (window.renderAdminPosts) {
-                        window.renderAdminPosts();
-                    }
-                    navLinks.forEach(link => link.classList.remove('active'));
-                } else {
-                    // Si no ha iniciado sesión, muestra el modal de login
-                    showLoginModal();
+                if (!isAdminLoggedIn) {
+                    // If not logged in and trying to access #admin, redirect to home
+                    window.location.hash = '#presentacion';
+                    return;
                 }
+                // If logged in, the panel is already shown by the login function.
+                // This logic ensures that if they are logged in, they stay on the admin page.
+                sections.forEach(section => section.classList.remove('active'));
+                adminPanelSection.classList.add('active');
+                navLinks.forEach(link => link.classList.remove('active'));
+
             } else {
                 // Ocultar el panel de administración y mostrar la sección normal
                 adminPanelSection.classList.remove('active');
@@ -1277,6 +1274,28 @@
             type();
             // Llama a la función de manejo de hash al cargar la página
             handleHashChange();
+
+            const footer = document.getElementById('main-footer');
+            let clickCount = 0;
+            let clickTimer = null;
+
+            footer.addEventListener('click', () => {
+                clickCount++;
+                if (clickTimer) {
+                    clearTimeout(clickTimer);
+                }
+                clickTimer = setTimeout(() => {
+                    clickCount = 0; // Reset after 2 seconds
+                }, 2000);
+
+                if (clickCount === 5) {
+                    clickCount = 0;
+                    clearTimeout(clickTimer);
+                    if (!isAdminLoggedIn) {
+                        showLoginModal();
+                    }
+                }
+            });
         };
 
         // Escucha los cambios en el hash de la URL


### PR DESCRIPTION
This commit changes the trigger for the admin login modal to improve compatibility with mobile browsers, following user feedback that the hash-based trigger was not working on their device.

- The `handleHashChange` function is modified to no longer trigger the login modal via the `#admin` hash. Instead, it redirects unauthenticated users to the homepage.
- A new event listener is added to the footer. Clicking the footer 5 times in quick succession now opens the login modal. This provides a more robust and device-agnostic way to access the hidden admin panel.