### PR TITLE
fix: Add specific error messages for storage failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,8 +90,12 @@
                 return;
             }
 
-            if (!window.firebaseStorage || !window.currentUserId) {
-                showMessageModal('Error: El servicio de almacenamiento no está disponible.');
+            if (!window.currentUserId) {
+                showMessageModal('Error de autenticación: No se pudo verificar el usuario. Por favor, recarga la página e intenta de nuevo.');
+                return;
+            }
+            if (!window.firebaseStorage) {
+                showMessageModal('Error de configuración: El servicio de almacenamiento no está inicializado. Revisa la configuración de Firebase.');
                 return;
             }
 


### PR DESCRIPTION
This commit adds more specific error messages to the `saveProfilePicture` function.

Instead of a generic "storage service not available" error, the code now checks for `currentUserId` and `firebaseStorage` separately. This will help diagnose the root cause of the file upload failure the user is experiencing on their deployed site, distinguishing between an authentication/timing issue and a Firebase project configuration issue.